### PR TITLE
Add per-player hide-after-found treasure visibility

### DIFF
--- a/plugin/src/main/java/de/theredend2000/advancedhunt/data/SqlRepository.java
+++ b/plugin/src/main/java/de/theredend2000/advancedhunt/data/SqlRepository.java
@@ -160,6 +160,7 @@ public class SqlRepository implements DataRepository {
 
     private void registerMigrations() {
         schemaMigrations.put(1, this::createPerformanceIndexes);
+        schemaMigrations.put(2, this::addHideAfterFoundColumn);
     }
 
     @Override
@@ -363,6 +364,22 @@ public class SqlRepository implements DataRepository {
                 if (!e.getMessage().contains("already exists") && !e.getMessage().contains("Duplicate")) {
                     plugin.getLogger().warning("Failed to create index: " + e.getMessage());
                 }
+            }
+        }
+    }
+
+    /**
+     * Adds the hide_after_found column to ah_collections for per-player found-treasure hiding.
+     */
+    private void addHideAfterFoundColumn(Connection conn) {
+        try (java.sql.Statement stmt = conn.createStatement()) {
+            stmt.execute(
+                "ALTER TABLE ah_collections ADD COLUMN hide_after_found BOOLEAN DEFAULT FALSE");
+        } catch (SQLException e) {
+            // Column may already exist
+            if (!e.getMessage().contains("duplicate") && !e.getMessage().contains("already exists")
+                    && !e.getMessage().contains("Duplicate")) {
+                plugin.getLogger().warning("Failed to add hide_after_found column: " + e.getMessage());
             }
         }
     }
@@ -785,6 +802,7 @@ public class SqlRepository implements DataRepository {
                     c.setProgressResetCron(rs.getString("progress_reset_cron"));
                     c.setSinglePlayerFind(rs.getBoolean("single_player_find"));
                     c.setHideWhenNotAvailable(rs.getBoolean("hide_when_not_available"));
+                    c.setHideAfterFound(rs.getBoolean("hide_after_found"));
 
                     String defaultPreset = rs.getString("default_treasure_reward_preset_id");
                     if (defaultPreset != null && !defaultPreset.trim().isEmpty()) {
@@ -823,8 +841,8 @@ public class SqlRepository implements DataRepository {
                         // Save collection — include all columns to avoid REPLACE INTO dropping
                         // unlisted columns. Use upsert syntax appropriate for the backend.
                         final String upsertSql = useSqlite
-                            ? "INSERT INTO ah_collections (id, name, enabled, reset_cron, active_start, active_end, progress_reset_cron, single_player_find, rewards, default_treasure_reward_preset_id, hide_when_not_available) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET name=excluded.name, enabled=excluded.enabled, reset_cron=excluded.reset_cron, active_start=excluded.active_start, active_end=excluded.active_end, progress_reset_cron=excluded.progress_reset_cron, single_player_find=excluded.single_player_find, rewards=excluded.rewards, default_treasure_reward_preset_id=excluded.default_treasure_reward_preset_id, hide_when_not_available=excluded.hide_when_not_available"
-                            : "INSERT INTO ah_collections (id, name, enabled, reset_cron, active_start, active_end, progress_reset_cron, single_player_find, rewards, default_treasure_reward_preset_id, hide_when_not_available) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE name=VALUES(name), enabled=VALUES(enabled), reset_cron=VALUES(reset_cron), active_start=VALUES(active_start), active_end=VALUES(active_end), progress_reset_cron=VALUES(progress_reset_cron), single_player_find=VALUES(single_player_find), rewards=VALUES(rewards), default_treasure_reward_preset_id=VALUES(default_treasure_reward_preset_id), hide_when_not_available=VALUES(hide_when_not_available)";
+                            ? "INSERT INTO ah_collections (id, name, enabled, reset_cron, active_start, active_end, progress_reset_cron, single_player_find, rewards, default_treasure_reward_preset_id, hide_when_not_available, hide_after_found) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET name=excluded.name, enabled=excluded.enabled, reset_cron=excluded.reset_cron, active_start=excluded.active_start, active_end=excluded.active_end, progress_reset_cron=excluded.progress_reset_cron, single_player_find=excluded.single_player_find, rewards=excluded.rewards, default_treasure_reward_preset_id=excluded.default_treasure_reward_preset_id, hide_when_not_available=excluded.hide_when_not_available, hide_after_found=excluded.hide_after_found"
+                            : "INSERT INTO ah_collections (id, name, enabled, reset_cron, active_start, active_end, progress_reset_cron, single_player_find, rewards, default_treasure_reward_preset_id, hide_when_not_available, hide_after_found) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE name=VALUES(name), enabled=VALUES(enabled), reset_cron=VALUES(reset_cron), active_start=VALUES(active_start), active_end=VALUES(active_end), progress_reset_cron=VALUES(progress_reset_cron), single_player_find=VALUES(single_player_find), rewards=VALUES(rewards), default_treasure_reward_preset_id=VALUES(default_treasure_reward_preset_id), hide_when_not_available=VALUES(hide_when_not_available), hide_after_found=VALUES(hide_after_found)";
                         try (PreparedStatement ps = conn.prepareStatement(upsertSql)) {
                             ps.setString(1, collection.getId().toString());
                             ps.setString(2, collection.getName());
@@ -837,6 +855,7 @@ public class SqlRepository implements DataRepository {
                             ps.setString(9, gson.toJson(collection.getCompletionRewards()));
                             ps.setString(10, collection.getDefaultTreasureRewardPresetId() != null ? collection.getDefaultTreasureRewardPresetId().toString() : null);
                             ps.setBoolean(11, collection.isHideWhenNotAvailable());
+                            ps.setBoolean(12, collection.isHideAfterFound());
                             ps.executeUpdate();
                         }
 

--- a/plugin/src/main/java/de/theredend2000/advancedhunt/data/YamlRepository.java
+++ b/plugin/src/main/java/de/theredend2000/advancedhunt/data/YamlRepository.java
@@ -1187,8 +1187,9 @@ public class YamlRepository implements DataRepository {
                             c.setProgressResetCron(config.getString("progress-reset-cron"));
                             c.setSinglePlayerFind(config.getBoolean("single-player-find"));
                             // Support both old and new key names for backward compatibility
-                            c.setHideWhenNotAvailable(config.getBoolean("hide-when-not-available", 
+                            c.setHideWhenNotAvailable(config.getBoolean("hide-when-not-available",
                                 config.getBoolean("hide-when-disabled", false)));
+                            c.setHideAfterFound(config.getBoolean("hide-after-found", false));
 
                             String defaultPresetId = config.getString("default-treasure-reward-preset-id");
                             if (defaultPresetId != null && !defaultPresetId.trim().isEmpty()) {
@@ -1257,6 +1258,7 @@ public class YamlRepository implements DataRepository {
                 config.set("progress-reset-cron", collection.getProgressResetCron());
                 config.set("single-player-find", collection.isSinglePlayerFind());
                 config.set("hide-when-not-available", collection.isHideWhenNotAvailable());
+                config.set("hide-after-found", collection.isHideAfterFound());
                 config.set("default-treasure-reward-preset-id",
                     collection.getDefaultTreasureRewardPresetId() != null ? collection.getDefaultTreasureRewardPresetId().toString() : null);
 

--- a/plugin/src/main/java/de/theredend2000/advancedhunt/managers/TreasureInteractionHandler.java
+++ b/plugin/src/main/java/de/theredend2000/advancedhunt/managers/TreasureInteractionHandler.java
@@ -190,6 +190,9 @@ public final class TreasureInteractionHandler {
         player.sendMessage(plugin.getMessageManager().getMessage("treasure.found"));
 
         collectionManager.getCollectionById(treasureCore.getCollectionId()).ifPresent(collection -> {
+            if (collection.isHideAfterFound()) {
+                plugin.getTreasureVisibilityManager().hideFoundTreasureForPlayer(player, treasureCore);
+            }
             if (collection.isSinglePlayerFind()) {
                 plugin.getParticleManager().markTreasureAsGloballyClaimed(treasureCore.getId());
             }

--- a/plugin/src/main/java/de/theredend2000/advancedhunt/managers/TreasureVisibilityManager.java
+++ b/plugin/src/main/java/de/theredend2000/advancedhunt/managers/TreasureVisibilityManager.java
@@ -19,6 +19,7 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerCh
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerMultiBlockChange;
 import de.theredend2000.advancedhunt.Main;
 import de.theredend2000.advancedhunt.model.Collection;
+import de.theredend2000.advancedhunt.model.PlayerData;
 import de.theredend2000.advancedhunt.model.Treasure;
 import de.theredend2000.advancedhunt.model.TreasureCore;
 import de.theredend2000.advancedhunt.platform.PlatformAccess;
@@ -493,42 +494,56 @@ public class TreasureVisibilityManager implements Listener {
         Object playerObj = event.getPlayer();
         if (!(playerObj instanceof Player)) return;
         Player player = (Player) playerObj;
-        if (!isBypassEnabled(player)) return;
+
+        boolean bypass = isBypassEnabled(player);
+        boolean anyHideAfterFound = hasAnyHideAfterFoundCollections();
+        if (!bypass && !anyHideAfterFound) return;
 
         PacketTypeCommon packetType = event.getPacketType();
         if (packetType == PacketType.Play.Server.BLOCK_CHANGE) {
-            handleBlockChange(event, player);
+            handleBlockChange(event, player, bypass);
             return;
         }
         if (packetType == PacketType.Play.Server.MULTI_BLOCK_CHANGE) {
-            handleMultiBlockChange(event, player);
+            handleMultiBlockChange(event, player, bypass);
             return;
         }
         if (packetType == PacketType.Play.Server.CHUNK_DATA) {
-            handleChunkData(event, player);
+            handleChunkData(event, player, bypass);
         }
     }
 
-    private void handleBlockChange(PacketSendEvent event, Player player) {
+    private void handleBlockChange(PacketSendEvent event, Player player, boolean bypass) {
         WrapperPlayServerBlockChange wrapper = new WrapperPlayServerBlockChange(event);
         Vector3i pos = wrapper.getBlockPosition();
         if (pos == null) return;
 
         Location loc = new Location(player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
         TreasureCore core = treasureManager.getTreasureCoreAt(loc);
-        if (core == null || !isCollectionHidden(core.getCollectionId())) return;
+        if (core == null) return;
 
-        WrappedBlockState blockState = resolveWrappedBlockState(core, player);
-        if (blockState == null) return;
+        boolean collectionHidden = isCollectionHidden(core.getCollectionId());
 
-        wrapper.setBlockState(blockState);
-        wrapper.write();
-        event.markForReEncode(true);
+        if (bypass && collectionHidden) {
+            WrappedBlockState blockState = resolveWrappedBlockState(core, player);
+            if (blockState == null) return;
+            wrapper.setBlockState(blockState);
+            wrapper.write();
+            event.markForReEncode(true);
+            scheduleVirtualExtras(player, core, loc);
+            return;
+        }
 
-        scheduleVirtualExtras(player, core, loc);
+        if (!collectionHidden && shouldHideFoundForPlayer(core, player)) {
+            WrappedBlockState airState = WrappedBlockState.getByString("minecraft:air");
+            if (airState == null) return;
+            wrapper.setBlockState(airState);
+            wrapper.write();
+            event.markForReEncode(true);
+        }
     }
 
-    private void handleMultiBlockChange(PacketSendEvent event, Player player) {
+    private void handleMultiBlockChange(PacketSendEvent event, Player player, boolean bypass) {
         WrapperPlayServerMultiBlockChange wrapper = new WrapperPlayServerMultiBlockChange(event);
 
         Vector3i chunkPos = wrapper.getChunkPosition();
@@ -548,16 +563,22 @@ public class TreasureVisibilityManager implements Listener {
             Location loc = new Location(player.getWorld(), x, y, z);
 
             TreasureCore core = treasureManager.getTreasureCoreAt(loc);
-            if (core == null || !isCollectionHidden(core.getCollectionId())) {
-                continue;
+            if (core == null) continue;
+
+            boolean collectionHidden = isCollectionHidden(core.getCollectionId());
+
+            if (bypass && collectionHidden) {
+                WrappedBlockState state = resolveWrappedBlockState(core, player);
+                if (state == null) continue;
+                block.setBlockState(state);
+                changed = true;
+                scheduleVirtualExtras(player, core, loc);
+            } else if (!collectionHidden && shouldHideFoundForPlayer(core, player)) {
+                WrappedBlockState airState = WrappedBlockState.getByString("minecraft:air");
+                if (airState == null) continue;
+                block.setBlockState(airState);
+                changed = true;
             }
-
-            WrappedBlockState state = resolveWrappedBlockState(core, player);
-            if (state == null) continue;
-
-            block.setBlockState(state);
-            changed = true;
-            scheduleVirtualExtras(player, core, loc);
         }
 
         if (changed) {
@@ -567,7 +588,7 @@ public class TreasureVisibilityManager implements Listener {
         }
     }
 
-    private void handleChunkData(PacketSendEvent event, Player player) {
+    private void handleChunkData(PacketSendEvent event, Player player, boolean bypass) {
         WrapperPlayServerChunkData wrapper = new WrapperPlayServerChunkData(event);
 
         Column column = wrapper.getColumn();
@@ -585,10 +606,20 @@ public class TreasureVisibilityManager implements Listener {
         boolean changed = false;
 
         for (TreasureCore core : cores) {
-            if (core == null || !isCollectionHidden(core.getCollectionId())) continue;
+            if (core == null) continue;
             Location loc = core.getLocation();
             if (loc == null || loc.getWorld() == null) continue;
             if (!loc.getWorld().equals(player.getWorld())) continue;
+
+            boolean collectionHidden = isCollectionHidden(core.getCollectionId());
+
+            WrappedBlockState state = null;
+            if (bypass && collectionHidden) {
+                state = resolveWrappedBlockState(core, player);
+            } else if (!collectionHidden && shouldHideFoundForPlayer(core, player)) {
+                state = WrappedBlockState.getByString("minecraft:air");
+            }
+            if (state == null) continue;
 
             int y = loc.getBlockY();
             int sectionIndex = (y - minY) >> 4;
@@ -597,9 +628,6 @@ public class TreasureVisibilityManager implements Listener {
             BaseChunk section = sections[sectionIndex];
             if (section == null) continue;
 
-            WrappedBlockState state = resolveWrappedBlockState(core, player);
-            if (state == null) continue;
-
             int localX = loc.getBlockX() & 0xF;
             int localY = (y - minY) & 0xF;
             int localZ = loc.getBlockZ() & 0xF;
@@ -607,13 +635,92 @@ public class TreasureVisibilityManager implements Listener {
             section.set(localX, localY, localZ, state);
             changed = true;
 
-            scheduleVirtualExtras(player, core, loc);
+            if (bypass && collectionHidden) {
+                scheduleVirtualExtras(player, core, loc);
+            }
         }
 
         if (changed) {
             wrapper.setColumn(column);
             wrapper.write();
             event.markForReEncode(true);
+        }
+    }
+
+    /**
+     * Checks if a given treasure should be hidden for a specific player because
+     * the collection has hideAfterFound enabled and the player has already found it.
+     */
+    private boolean shouldHideFoundForPlayer(TreasureCore core, Player player) {
+        if (core == null || player == null) return false;
+        Optional<Collection> collectionOpt = collectionManager.getCollectionById(core.getCollectionId());
+        if (!collectionOpt.isPresent() || !collectionOpt.get().isHideAfterFound()) return false;
+
+        PlayerData data = plugin.getPlayerManager().getPlayerData(player.getUniqueId());
+        return data != null && data.hasFound(core.getId());
+    }
+
+    /**
+     * Quick check whether any loaded collection has hideAfterFound enabled.
+     * Used to skip packet interception entirely when no collection uses the feature.
+     */
+    private boolean hasAnyHideAfterFoundCollections() {
+        for (Collection c : collectionManager.getAllCollections()) {
+            if (c.isHideAfterFound()) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Refreshes hide-after-found visibility for all online players in a collection.
+     * Called when the hideAfterFound toggle is changed.
+     */
+    public void refreshHideAfterFound(Collection collection) {
+        if (collection == null || !isPacketEventsReady()) return;
+
+        List<TreasureCore> cores = treasureManager.getTreasureCoresInCollection(collection.getId());
+        if (cores.isEmpty()) return;
+
+        boolean hiding = collection.isHideAfterFound();
+
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            PlayerData data = plugin.getPlayerManager().getPlayerData(player.getUniqueId());
+            if (data == null) continue;
+
+            for (TreasureCore core : cores) {
+                if (core == null || !data.hasFound(core.getId())) continue;
+                Location loc = core.getLocation();
+                if (loc == null || loc.getWorld() == null) continue;
+                if (!loc.getWorld().equals(player.getWorld())) continue;
+
+                if (hiding) {
+                    WrappedBlockState airState = WrappedBlockState.getByString("minecraft:air");
+                    if (airState != null) {
+                        sendBlockChangeToPlayer(player, loc, airState);
+                    }
+                } else {
+                    WrappedBlockState state = resolveWrappedBlockState(core, player);
+                    if (state != null) {
+                        sendBlockChangeToPlayer(player, loc, state);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Immediately hides a single treasure for a player via a block change packet.
+     * Called right after a player finds a treasure in a hideAfterFound collection.
+     */
+    public void hideFoundTreasureForPlayer(Player player, TreasureCore core) {
+        if (player == null || core == null || !isPacketEventsReady()) return;
+        Location loc = core.getLocation();
+        if (loc == null || loc.getWorld() == null) return;
+        if (!loc.getWorld().equals(player.getWorld())) return;
+
+        WrappedBlockState airState = WrappedBlockState.getByString("minecraft:air");
+        if (airState != null) {
+            sendBlockChangeToPlayer(player, loc, airState);
         }
     }
 

--- a/plugin/src/main/java/de/theredend2000/advancedhunt/menu/collection/CollectionSettingsMenu.java
+++ b/plugin/src/main/java/de/theredend2000/advancedhunt/menu/collection/CollectionSettingsMenu.java
@@ -277,12 +277,23 @@ public class CollectionSettingsMenu extends Menu {
         // Hide After Found
         String enabled = plugin.getMessageManager().getMessage("gui.common.enabled", false);
         String disabled = plugin.getMessageManager().getMessage("gui.common.disabled", false);
-        addButton(39, new ItemBuilder(Material.GLASS_BOTTLE)
+        String hafStatus = collection.isHideAfterFound() ? enabled : disabled;
+        addButton(39, new ItemBuilder(collection.isHideAfterFound() ? Material.GLASS : Material.GLASS_BOTTLE)
                 .setDisplayName(plugin.getMessageManager().getMessage("gui.settings.hide_after_found.name", false))
                 .setLore(plugin.getMessageManager().getMessageList("gui.settings.hide_after_found.lore", false,
-                        "%status%", disabled).toArray(new String[0]))
+                        "%status%", hafStatus).toArray(new String[0]))
                 .build(), (e) -> {
-            playerMenuUtility.sendMessage("§c§lThis feature is currently in development.");
+            if (processing) return;
+            processing = true;
+
+            collection.setHideAfterFound(!collection.isHideAfterFound());
+            plugin.getCollectionManager().saveCollection(collection).thenRun(() -> {
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    plugin.getTreasureVisibilityManager().refreshHideAfterFound(collection);
+                    processing = false;
+                    this.refresh();
+                });
+            });
         });
 
         // Hide When Not Available

--- a/plugin/src/main/java/de/theredend2000/advancedhunt/model/Collection.java
+++ b/plugin/src/main/java/de/theredend2000/advancedhunt/model/Collection.java
@@ -13,6 +13,7 @@ public class Collection {
     private List<Reward> completionRewards; // Rewards for finding all treasures
     private UUID defaultTreasureRewardPresetId; // Applied to newly created treasures in this collection
     private boolean hideWhenNotAvailable; // If true, treasures are hidden when collection is not available
+    private boolean hideAfterFound; // If true, found treasures are hidden per-player via packets
 
     public Collection(UUID id, String name, boolean enabled) {
         this.id = Objects.requireNonNull(id, "Collection id cannot be null");
@@ -27,6 +28,7 @@ public class Collection {
         this.defaultTreasureRewardPresetId = null;
         this.progressResetCron = null;
         this.hideWhenNotAvailable = false;
+        this.hideAfterFound = false;
     }
 
     public UUID getId() {
@@ -151,6 +153,14 @@ public class Collection {
 
     public void setHideWhenNotAvailable(boolean hideWhenNotAvailable) {
         this.hideWhenNotAvailable = hideWhenNotAvailable;
+    }
+
+    public boolean isHideAfterFound() {
+        return hideAfterFound;
+    }
+
+    public void setHideAfterFound(boolean hideAfterFound) {
+        this.hideAfterFound = hideAfterFound;
     }
 
     @Override


### PR DESCRIPTION
Hide treasures via packets for players who have already found them when a collection enables hideAfterFound. Adds the toggle to CollectionSettingsMenu, persists it in YAML and SQL (with a hide_after_found column migration), and hides found treasures live on find and chunk/block updates.